### PR TITLE
Add runtime checks and type annotations 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.mypy_cache/
 __pycache__/
 test
 *.o

--- a/preprocessor.py
+++ b/preprocessor.py
@@ -16,7 +16,7 @@ def cchar(value: char):
     return "'{}'".format(value[0])
 
 def cbool(value: bool):
-    return str(value).lower()
+    return str(bool(value)).lower()
 
 def clist(value: Sequence[Any]):
     return "{" + ", ".join(map(repr, value)) + "}"

--- a/preprocessor.py
+++ b/preprocessor.py
@@ -1,23 +1,24 @@
 #!/usr/bin/env python3
 
 import json
-from pathlib import Path
 import re
 import sys
+from pathlib import Path
+from typing import Any, Sequence
 
 class char(str):
     pass
 
-def cstr(value):
+def cstr(value: str):
     return json.dumps(value)
 
-def cchar(value):
+def cchar(value: char):
     return "'{}'".format(value[0])
 
-def cbool(value):
+def cbool(value: bool):
     return str(value).lower()
 
-def clist(value):
+def clist(value: Sequence[Any]):
     return "{" + ", ".join(map(repr, value)) + "}"
 
 crepr_functions = {
@@ -36,7 +37,7 @@ def crepr(val):
 
     return repr(fn(val))
 
-def call(fn, *args):
+def call(fn: str, *args):
     return "{}({})".format(fn, repr(clist(args))[1:-1])
 
 def import_macros(code):

--- a/preprocessor.py
+++ b/preprocessor.py
@@ -7,13 +7,26 @@ from pathlib import Path
 from typing import Any, Sequence
 
 class char(str):
-    pass
+    def __init__(self, value):
+        super().__init__(value)
+
+        if len(self) != 1:
+            raise ValueError(f"char instance with multiple character: '{value}'")
 
 def cstr(value: str):
+    if not isinstance(value, str):
+        raise TypeError(f"Given a value of type '{type(value)}', expected str.")
+
     return json.dumps(value)
 
 def cchar(value: char):
-    return "'{}'".format(value[0])
+    if not isinstance(value, str):
+        # Allowing 'str' on purpose, so literrals are accepted
+        raise TypeError(f"Given a value of type '{type(value)}, expected char.'")
+    if len(value) != 1:
+        raise ValueError(f"Expected a single character, got '{value}'.")
+
+    return "'{}'".format(value)
 
 def cbool(value: bool):
     return str(bool(value)).lower()
@@ -33,7 +46,10 @@ crepr_functions = {
 }
 
 def crepr(val):
-    fn = crepr_functions[type(val)]
+    try:
+        fn = crepr_functions[type(val)]
+    except KeyError:
+        raise TypeError(f"'{type(val)}' isn't a supported crepr type.")
 
     return repr(fn(val))
 


### PR DESCRIPTION
- [x] Add type annotations so `mypy` can typecheck macro definitions.
- [x] Add runtime checks (for “types” & invariants) to make the API less brittle (reliably error-out on misuse).